### PR TITLE
unpkg went down again, switch to jsdelivr

### DIFF
--- a/swaggerui.html
+++ b/swaggerui.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <title>Swagger API</title>
 
-  <link rel="stylesheet" type="text/css" href="//unpkg.com/swagger-ui-dist/swagger-ui.css">
-  <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist/favicon-32x32.png" sizes="32x32"/>
-  <link rel="icon" type="image/png" href="//unpkg.com/swagger-ui-dist/favicon-16x16.png" sizes="16x16"/>
+  <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css">
+  <link rel="icon" type="image/png" href="//cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-32x32.png" sizes="32x32"/>
+  <link rel="icon" type="image/png" href="//cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-16x16.png" sizes="16x16"/>
   <style>
       html {
           box-sizing: border-box;
@@ -30,8 +30,8 @@
 <body>
 <div id="swagger-ui"></div>
 
-<script src="//unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-<script src="//unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+<script src="//cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+<script src="//cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
 <script>
   window.onload = function () {
     // Begin Swagger UI call region


### PR DESCRIPTION
Re: https://github.com/mjackson/unpkg/issues/361

The Unpkg CDN has been down for several hours, the general suggestion seems to be to move to jsdelivr. Open to other options/suggestions though.