### PR TITLE
Sort query params

### DIFF
--- a/field.go
+++ b/field.go
@@ -484,17 +484,17 @@ func (f *Field) ToSwaggerParameters(in string) (parameters []Parameter) {
 				param.CollectionFormat = "multi"
 			}
 			parameters = append(parameters, param)
+			slices.SortFunc(parameters, func(a, b Parameter) int {
+				if a.Name < b.Name {
+					return -1
+				}
+				if a.Name > b.Name {
+					return 1
+				}
+				return 0
+			})
 		}
 	}
-	slices.SortFunc(parameters, func(a, b Parameter) int {
-		if a.Name < b.Name {
-			return -1
-		}
-		if a.Name > b.Name {
-			return 1
-		}
-		return 0
-	})
 	return
 }
 

--- a/field.go
+++ b/field.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -485,6 +486,15 @@ func (f *Field) ToSwaggerParameters(in string) (parameters []Parameter) {
 			parameters = append(parameters, param)
 		}
 	}
+	slices.SortFunc(parameters, func(a, b Parameter) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
 	return
 }
 

--- a/router.go
+++ b/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jakecoffman/crud/option"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -122,6 +123,15 @@ func (r *Router) Add(specs ...Spec) error {
 		}
 		if spec.Validate.Query.Initialized() {
 			params := spec.Validate.Query.ToSwaggerParameters("query")
+			slices.SortFunc(params, func(a, b Parameter) int {
+				if a.Name < b.Name {
+					return -1
+				}
+				if a.Name > b.Name {
+					return 1
+				}
+				return 0
+			})
 			operation.Parameters = append(operation.Parameters, params...)
 		}
 		if spec.Validate.Header.Initialized() {

--- a/router.go
+++ b/router.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/jakecoffman/crud/option"
 	"regexp"
-	"slices"
 	"strings"
 )
 
@@ -123,15 +122,6 @@ func (r *Router) Add(specs ...Spec) error {
 		}
 		if spec.Validate.Query.Initialized() {
 			params := spec.Validate.Query.ToSwaggerParameters("query")
-			slices.SortFunc(params, func(a, b Parameter) int {
-				if a.Name < b.Name {
-					return -1
-				}
-				if a.Name > b.Name {
-					return 1
-				}
-				return 0
-			})
 			operation.Parameters = append(operation.Parameters, params...)
 		}
 		if spec.Validate.Header.Initialized() {
@@ -187,5 +177,6 @@ func pathParms(swaggerUrl string) (params []string) {
 }
 
 // SwaggerUiTemplate contains the html for swagger UI.
+//
 //go:embed swaggerui.html
 var SwaggerUiTemplate []byte

--- a/router.go
+++ b/router.go
@@ -177,6 +177,5 @@ func pathParms(swaggerUrl string) (params []string) {
 }
 
 // SwaggerUiTemplate contains the html for swagger UI.
-//
 //go:embed swaggerui.html
 var SwaggerUiTemplate []byte


### PR DESCRIPTION
It would be nice if the query params were always displayed in a consistent order. Alphabetical seems ideal.